### PR TITLE
Add packaged known_hosts file to UserKnownHosts.

### DIFF
--- a/reposync
+++ b/reposync
@@ -29,6 +29,11 @@ usage()
 force=false
 flags=-i
 fwduser=anoncvs
+# Append supplied known hosts to default UserKnownHosts
+knownhosts="~/.ssh/known_hosts, ~/.ssh/known_hosts2"
+if [[ -f /usr/local/share/examples/reposync/ssh_known_hosts ]]; then
+	knownhosts="$i /usr/local/share/examples/reposync/ssh_known_hosts"
+fi
 sets=www,xenocara,ports,src
 while getopts "fl:pqs:" c; do
 	case $c in
@@ -56,7 +61,11 @@ run_rsync()
 {
 	if [[ -n $fwduser ]]; then
 		# reach rsync on the server via an ssh port-forward
-		rsync -e "ssh -S $sockfile -o ControlMaster=auto -o ControlPersist=1m  -oBatchMode=Yes -W localhost:rsync -l $fwduser" "$@" 2>&1
+		opts="-S $sockfile -oControlMaster=auto"
+		opts="$opts -oControlPersist=1m -oBatchMode=yes"
+		opts="$opts -oUserKnownHostsFile='$knownhosts'"
+		opts="$opts -W localhost:rsync -l $fwduser"
+		rsync -e "ssh $opts" "$@" 2>&1
 	else
 		rsync "$@" 2>&1
 	fi

--- a/reposync
+++ b/reposync
@@ -61,7 +61,7 @@ run_rsync()
 {
 	if [[ -n $fwduser ]]; then
 		# reach rsync on the server via an ssh port-forward
-		opts="-S $sockfile -oControlMaster=auto"
+		opts="-S $sockfile -oControlMaster=auto -oUpdateHostKeys=no"
 		opts="$opts -oControlPersist=1m -oBatchMode=yes"
 		opts="$opts -oUserKnownHostsFile='$knownhosts'"
 		opts="$opts -W localhost:rsync -l $fwduser"


### PR DESCRIPTION
This adds the packaged ssh_known_hosts file, if it exists, to the
end of the UserKnownHosts option.  This means that if there are no
other host keys for a given server, the packaged ones will be used
rather than throwing a (silent) host key error.  If an unlisted
server, or a listed server wth an existing host key of a different
type is used, the behaviour remains unchanged.