### PR TITLE
Support syncing from more than one rsync server

### DIFF
--- a/reposync
+++ b/reposync
@@ -67,9 +67,10 @@ repodir=$(readlink -f "${2:-/cvs}")
 rundir=/var/db/reposync
 
 oldhash=invalid
-hashfile=$rundir/reposync.hash
-lockfile=$rundir/reposync.lock
-sockfile=$rundir/reposync.sock
+prefix=$rundir/$(echo $synchost | sed -E 's/[^A-Za-z0-9.-]+/_/g')
+hashfile=$prefix.hash
+lockfile=$prefix.lock
+sockfile=$prefix.sock
 
 run_rsync()
 {
@@ -142,7 +143,7 @@ _e=$?
 esac
 [[ $_e -eq 0 ]] || err "rsync error: $_t"
 # shellcheck disable=SC2086
-newhash="${synchost} ${sets} $(echo $_t | sha256)"
+newhash="${sets} $(echo $_t | sha256)"
 
 if [[ -r $hashfile ]]; then
 	age=$(($(date +%s) - $(stat -t %s -f %m $hashfile)))

--- a/reposync.1
+++ b/reposync.1
@@ -98,8 +98,8 @@ If the sync takes longer than
 seconds, display a warning and exit with an error code.
 .El
 .Sh FILES
-.Bl -tag -width "/var/db/reposync/reposync.hash" -compact
-.It Pa /var/db/reposync/reposync.hash
+.Bl -tag -width "/var/db/reposync/*.hash" -compact
+.It Pa /var/db/reposync/*.hash
 stores a hash of the CVSROOT directory listing to detect if the
 repository has not changed
 .It Pa /var/db/reposync/known_hosts


### PR DESCRIPTION
reposync happens to be perfectly suited to sync other CVS repositories via rsync (use '-p'). This patch munges the synchost and uses that as the prefix for the various files in /var/db/reposync, effectively making these per-synchost.